### PR TITLE
Fixed eslint error

### DIFF
--- a/src/js/CheckBox.ts
+++ b/src/js/CheckBox.ts
@@ -1,0 +1,1 @@
+export * from './CheckBox';


### PR DESCRIPTION
The lack of an actual `Checkbox.js` file in the `dist` folder produced after build causes errors to appear with some configurations of eslint, specifically with the `import/no-unresolved` rule that's bundled with the `eslint-plugin-import` plugin. See [#111](https://github.com/react-native-checkbox/react-native-checkbox/issues/111) and [#34 (comment)](https://github.com/react-native-checkbox/react-native-checkbox/issues/34#issuecomment-748033674). 

Patched using the workaround described [here](https://github.com/Microsoft/TypeScript/issues/8328#issuecomment-215179783), which produces a valid `Checkbox.d.ts` file at build-time.