### PR TITLE
Fix controlled component on Android

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBox.java
+++ b/src/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBox.java
@@ -7,31 +7,37 @@
 package com.reactnativecommunity.checkbox;
 
 import android.content.Context;
+
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatCheckBox;
 
 /** CheckBox that has its value controlled by JS. */
 /*package*/ class ReactCheckBox extends AppCompatCheckBox {
 
-  private boolean mAllowChange;
+  private OnCheckedChangeListener mOnCheckedChangeListener = null;
 
   public ReactCheckBox(Context context) {
     super(context);
-    mAllowChange = true;
   }
 
   @Override
   public void setChecked(boolean checked) {
-    if (mAllowChange) {
-      mAllowChange = false;
-      super.setChecked(checked);
+    // Log.d("checkbox", "checked: " + checked + " mAllowChange: " + mAllowChange);
+    if (mOnCheckedChangeListener != null) {
+      mOnCheckedChangeListener.onCheckedChanged(this, checked);
     }
+  }
+
+  @Override
+  public void setOnCheckedChangeListener(@Nullable OnCheckedChangeListener listener) {
+    super.setOnCheckedChangeListener(listener);
+    mOnCheckedChangeListener = listener;
   }
 
   /*package*/ void setOn(boolean on) {
     // If the checkbox has a different value than the value sent by JS, we must change it.
-    if (isChecked() != on) {
-      super.setChecked(on);
-    }
-    mAllowChange = true;
+    // Log.d("checkbox", "on: " + on + " mAllowChange: " + mAllowChange);
+    if (isChecked() == on) return;
+    super.setChecked(on);
   }
 }


### PR DESCRIPTION
As a controlled component, we should not change the internal value without authorization, it should always be controlled by the value passed in by JS.

Example code:
```js
export default () => {
  const [check, setCheck] = useState(false)

  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
        <Text>box 1: </Text>
        <CheckBox value={false} />
      </View>

      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
        <Text>box 2: </Text>
        <CheckBox value={check} onValueChange={setCheck} />
      </View>
    </View>
  )
}
```
Before fix:
![GIF2](https://user-images.githubusercontent.com/20365169/128803539-3a1ae841-ed5f-4c17-8a41-b0a1e22e8f78.gif)

After:
![GIF](https://user-images.githubusercontent.com/20365169/128803436-3845dc22-bafd-405d-b47f-243f5eb465b7.gif)
