### PR TITLE
fix(iOS): add values of accessibility on iOS

### DIFF
--- a/src/js/CheckBox.ios.tsx
+++ b/src/js/CheckBox.ios.tsx
@@ -114,9 +114,16 @@ class CheckBox extends React.Component<Props> {
   render() {
     // Do not use onValueChange directly from props
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const {style, onValueChange, disabled, ...props} = this.props;
+    const {accessible, style, onValueChange, disabled, ...props} = this.props;
     return (
-      <View pointerEvents={disabled ? 'none' : 'auto'}>
+      <View
+        pointerEvents={disabled ? 'none' : 'auto'}
+        accessible={accessible != null ? accessible : true}
+        accessibilityRole="checkbox"
+        accessibilityState={{
+          checked: props.value || false,
+          disabled: disabled || false,
+        }}>
         <IOSCheckBoxNativeComponent
           {...props}
           // @ts-ignore TODO: implement the type of IOSCheckBoxNativeComponent

--- a/src/js/__test__/CheckBox.test.tsx
+++ b/src/js/__test__/CheckBox.test.tsx
@@ -60,6 +60,12 @@ describe('render IOS <Checkbox />', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders IOS Checkbox with accessible={false} props', () => {
+    const tree = renderer.create(<IosCheckbox accessible={false} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders IOS Checkbox with full setting', () => {
     const tree = renderer
       .create(

--- a/src/js/__test__/__snapshots__/CheckBox.test.tsx.snap
+++ b/src/js/__test__/__snapshots__/CheckBox.test.tsx.snap
@@ -62,8 +62,45 @@ exports[`render Android <Checkbox /> renders enabled Android Checkbox 1`] = `
 />
 `;
 
+exports[`render IOS <Checkbox /> renders IOS Checkbox with accessible={false} props 1`] = `
+<View
+  accessibilityRole="checkbox"
+  accessibilityState={
+    Object {
+      "checked": false,
+      "disabled": false,
+    }
+  }
+  accessible={false}
+  pointerEvents="auto"
+>
+  <RNCCheckbox
+    forwardedRef={null}
+    onValueChange={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+          "height": 32,
+          "width": 32,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`render IOS <Checkbox /> renders IOS Checkbox with full setting 1`] = `
 <View
+  accessibilityRole="checkbox"
+  accessibilityState={
+    Object {
+      "checked": false,
+      "disabled": false,
+    }
+  }
+  accessible={true}
   pointerEvents="auto"
 >
   <RNCCheckbox
@@ -97,6 +134,14 @@ exports[`render IOS <Checkbox /> renders IOS Checkbox with full setting 1`] = `
 
 exports[`render IOS <Checkbox /> renders IOS Checkbox without disabled props 1`] = `
 <View
+  accessibilityRole="checkbox"
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
+  accessible={true}
   pointerEvents="auto"
 >
   <RNCCheckbox
@@ -119,6 +164,14 @@ exports[`render IOS <Checkbox /> renders IOS Checkbox without disabled props 1`]
 
 exports[`render IOS <Checkbox /> renders disabled IOS Checkbox 1`] = `
 <View
+  accessibilityRole="checkbox"
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": true,
+    }
+  }
+  accessible={true}
   pointerEvents="none"
 >
   <RNCCheckbox
@@ -141,6 +194,14 @@ exports[`render IOS <Checkbox /> renders disabled IOS Checkbox 1`] = `
 
 exports[`render IOS <Checkbox /> renders disabled false IOS Checkbox 1`] = `
 <View
+  accessibilityRole="checkbox"
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
+  accessible={true}
   pointerEvents="auto"
 >
   <RNCCheckbox
@@ -163,6 +224,14 @@ exports[`render IOS <Checkbox /> renders disabled false IOS Checkbox 1`] = `
 
 exports[`render IOS <Checkbox /> renders enabled IOS Checkbox 1`] = `
 <View
+  accessibilityRole="checkbox"
+  accessibilityState={
+    Object {
+      "checked": false,
+      "disabled": false,
+    }
+  }
+  accessible={true}
   pointerEvents="auto"
 >
   <RNCCheckbox
@@ -184,6 +253,14 @@ exports[`render IOS <Checkbox /> renders enabled IOS Checkbox 1`] = `
 
 exports[`render IOS <Checkbox /> renders hideBox IOS Checkbox 1`] = `
 <View
+  accessibilityRole="checkbox"
+  accessibilityState={
+    Object {
+      "checked": true,
+      "disabled": false,
+    }
+  }
+  accessible={true}
   pointerEvents="auto"
 >
   <RNCCheckbox


### PR DESCRIPTION
On iOS, the checkbox is not focusable by screen readers and does not recognize if it has been checked.
This PR isn't perfect, but it supports screen readers by default.

*before*
![before](https://user-images.githubusercontent.com/40130327/130411147-d106d3ba-d623-4e33-8c3b-40cb14879659.png)

*after*
![after1](https://user-images.githubusercontent.com/40130327/130411208-601ecbcb-2244-4227-804e-c707e102ad27.png)
![after2](https://user-images.githubusercontent.com/40130327/130411214-52134a06-f338-4a5a-b1d8-a580c4a3312c.png)

