### PR TITLE
make `react-native-windows` an optional `peerDependency`

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -47,6 +47,11 @@
     "react-native": ">= 0.62",
     "react-native-windows": ">=0.62"
   },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
+  }
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
While installing this, I get this warning
```
npm WARN @react-native-community/checkbox@0.5.9 requires a peer of react-native-windows@>=0.62 but none is installed. You must install peer dependencies yourself.
```

Peer dependencies are automatically installed on npm v7+, which is probably not what we want for non react-native-windows users.

References: 
[This twitter thread](https://twitter.com/satya164/status/1460929480248152068?s=21) 
[NPM dependency docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies)