### PR TITLE
fix(iOS): expose `testID` from wrapping view component.

### DIFF
--- a/src/js/CheckBox.ios.tsx
+++ b/src/js/CheckBox.ios.tsx
@@ -120,10 +120,12 @@ class CheckBox extends React.Component<Props> {
       onValueChange,
       disabled,
       value,
+      testID,
       ...props
     } = this.props;
     return (
       <View
+        testID={testID}
         pointerEvents={disabled ? 'none' : 'auto'}
         accessible={accessible != null ? accessible : true}
         accessibilityRole="checkbox"


### PR DESCRIPTION
Before this change, `testID` was exposed from the native sub component `IOSCheckBoxNativeComponent`.

However, this component does not expose the accessibility info (`accessible`, `accessibilityRole`, etc.), which is exposed in the parent RN component `View`.

Thus, retrieving this information on tests by the `testID` is not possible unless accessing the parent view.