### PR TITLE
fix(types): utility type removed from RN 0.71

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,12 +1,14 @@
 import {Component} from 'react';
-import {Constructor, NativeMethodsMixin} from 'react-native';
+import {NativeMethods} from 'react-native';
 import {Props as AndroidProps} from '../dist/CheckBox.android';
 import {Props as IOSProps} from '../dist/CheckBox.ios';
 import {Props as WindowsProps} from '../dist/CheckBox.windows';
 
+type Constructor<T> = new (...args: any[]) => T;
+
 type CheckBoxProps = AndroidProps & IOSProps & WindowsProps;
 
 declare class CheckBoxComponent extends Component<CheckBoxProps> {}
-declare const CheckBoxBase: Constructor<NativeMethodsMixin> &
+declare const CheckBoxBase: Constructor<NativeMethods> &
   typeof CheckBoxComponent;
 export default class CheckBox extends CheckBoxBase {}


### PR DESCRIPTION
Since react-native v0.71 bundles typescript types, some private types are not exported: https://github.com/facebook/react-native/blob/v0.71.1/types/private/Utilities.d.ts

Also, `NativeMethodsMixin` has been deprecated, replaced by `NativeMethods`.

resolve: #188 
