### PR TITLE
fix: windows bump WindowsTargetPlatformMinVersion

### DIFF
--- a/src/windows/CheckboxWindows/CheckboxWindows.vcxproj
+++ b/src/windows/CheckboxWindows/CheckboxWindows.vcxproj
@@ -15,7 +15,7 @@
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">


### PR DESCRIPTION
In RNW .72, we bump WinUI from 2.7 to 2.8 which targets a higher TargetPlatformMinVersion. This PR bumps the WindowsTargetPlatformMinVersion to the correct version for RNW .72