### PR TITLE
fix: setAndForwardRef

### DIFF
--- a/src/js/CheckBox.android.tsx
+++ b/src/js/CheckBox.android.tsx
@@ -17,7 +17,7 @@ import {
   NativeSyntheticEvent,
 } from 'react-native';
 // @ts-ignore setAndForwardRef type does not exist in @types/react-native
-import setAndForwardRef from 'react-native/Libraries/Utilities/setAndForwardRef';
+import setAndForwardRef from './setAndForwardRef';
 
 import AndroidCheckBoxNativeComponent from './AndroidCheckBoxNativeComponent';
 

--- a/src/js/CheckBox.ios.tsx
+++ b/src/js/CheckBox.ios.tsx
@@ -19,7 +19,7 @@ import {
 } from 'react-native';
 import IOSCheckBoxNativeComponent from './IOSCheckBoxNativeComponent';
 // @ts-ignore setAndForwardRef type does not exist in @types/react-native
-import setAndForwardRef from 'react-native/Libraries/Utilities/setAndForwardRef';
+import setAndForwardRef from './setAndForwardRef';
 
 type CheckBoxEvent = NativeSyntheticEvent<
   Readonly<{

--- a/src/js/CheckBox.windows.tsx
+++ b/src/js/CheckBox.windows.tsx
@@ -19,7 +19,7 @@ import {
 } from 'react-native';
 import WindowsCheckBoxNativeComponent from './WindowsCheckBoxComponent';
 // @ts-ignore setAndForwardRef type does not exist in @types/react-native
-import setAndForwardRef from 'react-native/Libraries/Utilities/setAndForwardRef';
+import setAndForwardRef from './setAndForwardRef';
 
 type CheckBoxEvent = NativeSyntheticEvent<
   Readonly<{

--- a/src/js/setAndForwardRef.ts
+++ b/src/js/setAndForwardRef.ts
@@ -1,0 +1,63 @@
+/**
+ * Imported from RN .71
+ */
+
+import type {ElementRef} from 'react';
+
+type Args = {
+  getForwardedRef: () => React.Ref<any> | undefined;
+  setLocalRef: (ref: ElementRef<any>) => any;
+};
+
+/**
+ * This is a helper function for when a component needs to be able to forward a ref
+ * to a child component, but still needs to have access to that component as part of
+ * its implementation.
+ *
+ * Its main use case is in wrappers for native components.
+ *
+ * Usage:
+ *
+ *   class MyView extends React.Component {
+ *     _nativeRef = null;
+ *
+ *     _setNativeRef = setAndForwardRef({
+ *       getForwardedRef: () => this.props.forwardedRef,
+ *       setLocalRef: ref => {
+ *         this._nativeRef = ref;
+ *       },
+ *     });
+ *
+ *     render() {
+ *       return <View ref={this._setNativeRef} />;
+ *     }
+ *   }
+ *
+ *   const MyViewWithRef = React.forwardRef((props, ref) => (
+ *     <MyView {...props} forwardedRef={ref} />
+ *   ));
+ *
+ *   module.exports = MyViewWithRef;
+ */
+
+function setAndForwardRef({
+  getForwardedRef,
+  setLocalRef,
+}: Args): (ref: ElementRef<any>) => void {
+  return function forwardRef(ref: ElementRef<any>) {
+    let forwardedRef = getForwardedRef();
+
+    setLocalRef(ref);
+
+    // Forward to user ref prop (if one has been specified)
+    if (typeof forwardedRef === 'function') {
+      // Handle function-based refs. String-based refs are handled as functions.
+      forwardedRef(ref);
+    } else if (typeof forwardedRef === 'object' && forwardedRef != null) {
+      // Handle createRef-based refs
+      forwardedRef = ref;
+    }
+  };
+}
+
+export default setAndForwardRef;


### PR DESCRIPTION
The function setAndForwardRef has been removed from React-Native .72 (see https://github.com/facebook/react-native/commit/bf6ed07c0f01f788e6554ad63c958feec3d2eb0c). This PR adds the method to the react-native-checkbox repository.

Tested on React-Native-Gallery, should also be tested on IOS/Android