### PR TITLE
fix(#226): NPE crash RN 0.76.1 - Support for new architecture

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -20,6 +20,14 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['ReactNativeCheckBox_' + name]).toInteger()
 }
 
+def isNewArchitectureEnabled() {
+  // To opt-in for the New Architecture, you can either:
+  // - Set `newArchEnabled` to true inside the `gradle.properties` file
+  // - Invoke gradle with `-newArchEnabled=true`
+  // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
+  return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
 android {
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
     buildToolsVersion getExtOrDefault('buildToolsVersion')
@@ -27,6 +35,7 @@ android {
     defaultConfig {
         minSdkVersion getExtOrIntegerDefault('minSdkVersion')
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }
 
     lintOptions {
@@ -42,4 +51,4 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 }
-  
+

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -23,7 +23,7 @@ def getExtOrIntegerDefault(name) {
 def isNewArchitectureEnabled() {
   // To opt-in for the New Architecture, you can either:
   // - Set `newArchEnabled` to true inside the `gradle.properties` file
-  // - Invoke gradle with `-newArchEnabled=true`
+  // - Invoke gradle with `-PnewArchEnabled=true` or `--project-prop newArchEnabled=true`
   // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
   return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }

--- a/src/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBoxManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBoxManager.java
@@ -17,9 +17,12 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.common.UIManagerType;
+import com.facebook.react.uimanager.events.EventDispatcher;
 
 import javax.annotation.Nullable;
 
@@ -33,9 +36,18 @@ public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
         @Override
         public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
           ReactContext reactContext = getReactContext(buttonView);
-          reactContext
-              .getNativeModule(UIManagerModule.class).getEventDispatcher()
-              .dispatchEvent(new ReactCheckBoxEvent(buttonView.getId(), isChecked));
+          EventDispatcher eventDispatcher;
+          try {
+            if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+              eventDispatcher = UIManagerHelper.getUIManager(reactContext, UIManagerType.FABRIC).getEventDispatcher();
+            } else {
+              eventDispatcher = reactContext
+                .getNativeModule(UIManagerModule.class).getEventDispatcher();
+            }
+            eventDispatcher.dispatchEvent(new ReactCheckBoxEvent(buttonView.getId(), isChecked));
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
         }
 
         private ReactContext getReactContext(CompoundButton buttonView) {

--- a/src/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBoxManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/checkbox/ReactCheckBoxManager.java
@@ -45,8 +45,8 @@ public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
                 .getNativeModule(UIManagerModule.class).getEventDispatcher();
             }
             eventDispatcher.dispatchEvent(new ReactCheckBoxEvent(buttonView.getId(), isChecked));
-          } catch (Exception e) {
-            throw new RuntimeException(e);
+          } catch (NullPointerException | IllegalStateException e) {
+            android.util.Log.e("ReactCheckBoxManager", "Error dispatching checkbox event", e);
           }
         }
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/checkbox",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "React Native Checkbox native modules for Android , iOS and Windows",
   "keywords": [
     "checkbox",


### PR DESCRIPTION
Fix NPE crash in ReactCheckBoxManager on RN >= 0.76.1 