### PR TITLE
Add support for accessibilityLabel prop

### DIFF
--- a/src/js/CheckBox.ios.tsx
+++ b/src/js/CheckBox.ios.tsx
@@ -117,6 +117,7 @@ class CheckBox extends React.Component<Props> {
 
   render() {
     const {
+      accessibilityLabel,
       accessible,
       style,
       // Do not use onValueChange directly from props
@@ -132,6 +133,7 @@ class CheckBox extends React.Component<Props> {
         testID={testID}
         pointerEvents={disabled ? 'none' : 'auto'}
         accessible={accessible != null ? accessible : true}
+        accessibilityLabel={accessibilityLabel}
         accessibilityRole="checkbox"
         accessibilityState={{
           checked: value || false,

--- a/src/js/__test__/CheckBox.test.tsx
+++ b/src/js/__test__/CheckBox.test.tsx
@@ -64,6 +64,7 @@ describe('render IOS <Checkbox />', () => {
   it('renders IOS Checkbox with full setting', () => {
     const {toJSON} = render(
       <IosCheckbox
+        accessibilityLabel="Test Checkbox"
         value={false}
         onValueChange={() => {}}
         onAnimationDidStop={() => {}}

--- a/src/js/__test__/__snapshots__/CheckBox.test.tsx.snap
+++ b/src/js/__test__/__snapshots__/CheckBox.test.tsx.snap
@@ -98,6 +98,7 @@ exports[`render IOS <Checkbox /> renders IOS Checkbox with accessible={false} pr
 
 exports[`render IOS <Checkbox /> renders IOS Checkbox with full setting 1`] = `
 <View
+  accessibilityLabel="Test Checkbox"
   accessibilityRole="checkbox"
   accessibilityState={
     {


### PR DESCRIPTION
This PR adds support for accessibilityLabel, which now can be passed to RNCCheckbox to improve accessibility and testability of the component.