### PR TITLE
Restore default export and fix typings after new-arch merge

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/checkbox",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "React Native Checkbox native modules for Android, iOS, and Windows",
   "keywords": ["checkbox", "react native", "react-native"],
   "homepage": "https://github.com/react-native-community/react-native-checkbox#readme",

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "author": "Nicholas Lee <nicholaslee119@gmail.com>",
-  "main": "dist/js/index",
+  "main": "dist/js/CheckBox",
   "types": "typings/index.d.ts",
 
   "scripts": {

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,8 +1,8 @@
 import {Component} from 'react';
 import {NativeMethods} from 'react-native';
-import {Props as AndroidProps} from '../dist/CheckBox.android';
-import {Props as IOSProps} from '../dist/CheckBox.ios';
-import {Props as WindowsProps} from '../dist/CheckBox.windows';
+import {Props as AndroidProps} from '../dist/js/CheckBox.android';
+import {Props as IOSProps} from '../dist/js/CheckBox.ios';
+import {Props as WindowsProps} from '../dist/js/CheckBox.windows';
 
 type Constructor<T> = new (...args: any[]) => T;
 


### PR DESCRIPTION
This pull request updates the package metadata in `src/package.json` to align with the correct versioning and entry point for the `@react-native-community/checkbox` package.

Package metadata updates:

* Downgraded the package version from `1.0.0` to `0.6.0` to reflect the correct version.
* Changed the main entry point from `dist/js/index` to `dist/js/CheckBox` for accurate module resolution.