### PR TITLE
chore: add prepublishOnly script to build dist before publish

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -15,6 +15,7 @@
 
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "windows": "npx @react-native-community/cli run-windows",
     "test:windows": "jest --config jest.config.windows.js"
   },


### PR DESCRIPTION
## Overview

Ensures `dist/` is always built before publishing to npm.

## Problem

The package publishes compiled output from `dist/` (source `js/` is excluded via `.npmignore`), but there was **no lifecycle script to build it**. Running `npm publish` without first running `npm run build` would ship a stale or empty `dist/`, breaking all consumers.

## Fix

Add `"prepublishOnly": "npm run build"` so the build runs automatically on `npm publish`.

## Verification

With `dist/` removed, `npm publish --dry-run` triggers `prepublishOnly → build → tsc`, and the resulting tarball contains the three platform files (`CheckBox.android/ios/windows.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)