### PR TITLE
fix(ios): make CheckBox a controlled component (#103, #216, #162)

### DIFF
--- a/src/js/CheckBox.ios.tsx
+++ b/src/js/CheckBox.ios.tsx
@@ -104,11 +104,15 @@ class CheckBox extends React.Component<Props> {
   _onChange = (event: CheckBoxEvent) => {
     const {onValueChange, onChange} = this.props;
 
-    const {value} = event.nativeEvent;
+    // Reset the native checkbox back to the controlled `value` prop so the
+    // component behaves as a controlled input. Without this, iOS would keep
+    // whatever state the native tap produced, ignoring the `value` prop.
+    // This mirrors the Android implementation.
+    const value = this.props.value || false;
     // @ts-ignore
     nullthrows(this._nativeRef).setNativeProps({value});
     onChange && onChange(event);
-    onValueChange && onValueChange(value);
+    onValueChange && onValueChange(event.nativeEvent.value);
   };
 
   render() {

--- a/src/js/__test__/CheckBox.ios.controlled.test.tsx
+++ b/src/js/__test__/CheckBox.ios.controlled.test.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import {render} from '@testing-library/react-native';
+
+// Capture the props the CheckBox passes to the native component so the test
+// can drive the onChange handler and observe how the native view is reset.
+// Names are prefixed with `mock` so jest.mock's factory may reference them.
+const mockState: {nativeProps: any} = {nativeProps: null};
+const mockSetNativeProps = jest.fn();
+
+jest.mock('../IOSCheckBoxNativeComponent', () => {
+  const ReactModule = require('react');
+  return {
+    __esModule: true,
+    default: ReactModule.forwardRef((props: any, ref: any) => {
+      mockState.nativeProps = props;
+      ReactModule.useImperativeHandle(ref, () => ({
+        setNativeProps: mockSetNativeProps,
+      }));
+      return ReactModule.createElement('RNCCheckbox', props);
+    }),
+  };
+});
+
+import IosCheckbox from '../CheckBox.ios';
+
+beforeEach(() => {
+  mockState.nativeProps = null;
+  mockSetNativeProps.mockClear();
+});
+
+describe('iOS CheckBox controlled behavior (issue #103)', () => {
+  it('resets the native view to the `value` prop and reports the tapped value', () => {
+    const onValueChange = jest.fn();
+    const onChange = jest.fn();
+
+    render(
+      <IosCheckbox
+        value={true}
+        onValueChange={onValueChange}
+        onChange={onChange}
+      />,
+    );
+
+    // Simulate a tap that toggles the native checkbox off.
+    const event = {nativeEvent: {value: false, target: 1, name: 'tap'}};
+    mockState.nativeProps.onValueChange(event);
+
+    // onValueChange receives the value produced by the native tap...
+    expect(onValueChange).toHaveBeenCalledWith(false);
+    expect(onChange).toHaveBeenCalledWith(event);
+    // ...but the native view is reset to the controlled `value` prop (true),
+    // so the iOS checkbox stays in sync with the controlled state instead of
+    // drifting to whatever the tap produced.
+    expect(mockSetNativeProps).toHaveBeenLastCalledWith({value: true});
+  });
+
+  it('keeps the native view off when the controlled value is false', () => {
+    const onValueChange = jest.fn();
+
+    render(<IosCheckbox value={false} onValueChange={onValueChange} />);
+
+    mockState.nativeProps.onValueChange({
+      nativeEvent: {value: true, target: 1, name: 'tap'},
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith(true);
+    expect(mockSetNativeProps).toHaveBeenLastCalledWith({value: false});
+  });
+});


### PR DESCRIPTION
## Summary

On iOS the checkbox did not behave as a controlled component: after a tap it kept whatever state the native `BEMCheckBox` produced instead of resetting to the `value` prop. As a result, setting `value={true}` (or forcing `false` inside `onValueChange`) did not prevent the box from toggling on tap — the UI drifted out of the controlled state.

The Android implementation already resets the native view back to `this.props.value` on change. This PR aligns iOS with that behavior:

- Reset the native view to `this.props.value` (instead of `event.nativeEvent.value`).
- Still report the tapped value through `onValueChange`, so the parent decides whether to update state.

Fixes #103. Also addresses the same root cause behind #216 and #162.

## Changes

- `src/js/CheckBox.ios.tsx` — reset native props to the controlled `value`.
- `src/js/__test__/CheckBox.ios.controlled.test.tsx` — new regression tests covering `value={true}` and `value={false}`. Verified the tests fail when the fix is reverted.

## Testing

`yarn test` (jest + eslint + type-check) passes — 16 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)