### PR TITLE
fix(android): enable BuildConfig generation for AGP 9 (#257)

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -57,6 +57,10 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 repositories {


### PR DESCRIPTION
AGP 9 disables BuildConfig generation by default for library modules.

This package defines custom BuildConfig fields in `defaultConfig`, which causes Android configuration to fail.

Enable `buildFeatures.buildConfig` explicitly to restore compatibility with AGP 9.

Fixes #257 