### PR TITLE
fix(codegen): support React Native 0.87

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'com.facebook.react'
 
 def getExtOrDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['ReactNativeCheckBox_' + name]

--- a/src/package.json
+++ b/src/package.json
@@ -61,7 +61,7 @@
   "codegenConfig": {
     "name": "RNCCheckboxSpec",
     "type": "all",
-    "jsSrcsDir": "js",
+    "jsSrcsDir": "dist/js",
     "windows": {
       "namespace": "CheckboxCodegen",
       "outputDirectory": "windows/Checkbox/codegen",


### PR DESCRIPTION
## Summary

Fixes React Native Codegen for the published package on both iOS and Android with React Native 0.87.

The package currently declares:

`"jsSrcsDir": "js"`

but the published npm package contains the Codegen sources under `dist/js`.

With React Native 0.87, iOS `pod install` fails during Codegen with:

`ENOENT: no such file or directory, lstat '.../@react-native-community/checkbox/js'`

Changing `jsSrcsDir` to `dist/js` points Codegen to the actual published JavaScript sources.

On Android, the React Native Gradle plugin also needs to be applied so that the Codegen artifacts for `RNCCheckboxSpec` are generated. Without it, the Android build fails because the generated JNI sources are missing:

`RNCCheckboxSpec.h: file not found`

Applying `com.facebook.react` enables the library's Android Codegen tasks and generates the required artifacts.

## Tested

- React Native 0.87.1
- New Architecture
- iOS: `pod install` completes successfully
- Android: Codegen runs and the app builds successfully